### PR TITLE
Changed the update and create actions to return the exercise rather than the index

### DIFF
--- a/lib/our_fitness_pal_api_web/controllers/exercise_controller.ex
+++ b/lib/our_fitness_pal_api_web/controllers/exercise_controller.ex
@@ -15,9 +15,8 @@ defmodule OurFitnessPalApiWeb.ExerciseController do
 
   def create(conn, %{"exercise" => exercise}) do
     case Workouts.create_exercise(exercise) do
-      {:ok, _exercise} ->
-        exercises = Workouts.list_exercises
-        render conn, "index.json", %{exercises: exercises, message: "Exercise created"}
+      {:ok, exercise} ->
+        render conn, "show.json", exercise: exercise, message: "Exercise created"
       {:error, changeset} ->
         render conn, "errors.json", changeset: changeset
     end
@@ -26,9 +25,8 @@ defmodule OurFitnessPalApiWeb.ExerciseController do
   def update(conn, %{"id" => exercise_id, "exercise" => exercise}) do
     old_exercise = Workouts.get_exercise!(exercise_id)
     case Workouts.update_exercise(old_exercise, exercise) do
-      {:ok, _exercise} ->
-        exercises = Workouts.list_exercises
-        render conn, "index.json", exercises: exercises, message: "Exercise updated"
+      {:ok, exercise} ->
+        render conn, "show.json", exercise: exercise, message: "Exercise updated"
       {:error, changeset} ->
         render conn, "errors.json", changeset: changeset
     end

--- a/lib/our_fitness_pal_api_web/views/exercise_view.ex
+++ b/lib/our_fitness_pal_api_web/views/exercise_view.ex
@@ -8,8 +8,9 @@ defmodule OurFitnessPalApiWeb.ExerciseView do
     }
   end
 
-  def render("show.json", %{exercise: exercise}) do
-    %{exercise: exercise_json(exercise)}
+  def render("show.json", %{exercise: exercise} = params) do
+    message = params[:message] || ""
+    %{exercise: exercise_json(exercise), message: message}
   end
 
   def render("errors.json", %{changeset: changeset}) do

--- a/test/our_fitness_pal_api_web/controllers/exercise_controller_test.exs
+++ b/test/our_fitness_pal_api_web/controllers/exercise_controller_test.exs
@@ -37,7 +37,8 @@ defmodule OurFitnessPalApiWeb.ExerciseControllerTest do
         "name" => exercise.name,
         "description" => exercise.description,
         "id" => exercise.id
-      }
+      },
+      "message" => ""
     }
   end
 
@@ -49,11 +50,11 @@ defmodule OurFitnessPalApiWeb.ExerciseControllerTest do
       |> List.first
 
     assert json_response(conn, 200) == %{
-      "exercises" => [%{
+      "exercise" => %{
         "name" => exercise.name,
         "description" => exercise.description,
         "id" => exercise.id
-      }],
+      },
       "message" => "Exercise created"
     }
   end
@@ -86,11 +87,11 @@ defmodule OurFitnessPalApiWeb.ExerciseControllerTest do
     assert updated_exercise.description == @valid_attrs.description
 
     assert json_response(conn, 200) == %{
-      "exercises" => [%{
+      "exercise" => %{
         "name" => updated_exercise.name,
         "description" => updated_exercise.description,
         "id" => exercise.id
-      }],
+      },
       "message" => "Exercise updated"
     }
   end

--- a/test/our_fitness_pal_api_web/views/exercise_view_test.exs
+++ b/test/our_fitness_pal_api_web/views/exercise_view_test.exs
@@ -35,7 +35,8 @@ defmodule OurFitnessPalApiWeb.ExerciseViewTest do
     rendered_exercise = ExerciseView.render("show.json", %{exercise: exercise})
 
     assert rendered_exercise == %{
-      exercise: ExerciseView.exercise_json(exercise)
+      exercise: ExerciseView.exercise_json(exercise),
+      message: ""
     }
   end
 


### PR DESCRIPTION
Why?
- The front end expects to receive the exercise not the whole index.

How?
- Updated the show template  to display messages.
- Updated the update and create actions to render the show template instead of the index.