### PR TITLE
Changed the exercise delete action to respond with the deleted exercise

### DIFF
--- a/lib/our_fitness_pal_api_web/controllers/exercise_controller.ex
+++ b/lib/our_fitness_pal_api_web/controllers/exercise_controller.ex
@@ -35,9 +35,8 @@ defmodule OurFitnessPalApiWeb.ExerciseController do
   def delete(conn, %{"id" => exercise_id}) do
     old_exercise = Workouts.get_exercise!(exercise_id)
     case Workouts.delete_exercise(old_exercise) do
-      {:ok, _exercise} ->
-        exercises = Workouts.list_exercises
-        render conn, "index.json", exercises: exercises, message: "Exercise deleted"
+      {:ok, exercise} ->
+        render conn, "show.json", exercise: exercise, message: "Exercise deleted"
       {:error, changeset} ->
         render conn, "errors.json", changeset: changeset
     end

--- a/test/our_fitness_pal_api_web/controllers/exercise_controller_test.exs
+++ b/test/our_fitness_pal_api_web/controllers/exercise_controller_test.exs
@@ -118,15 +118,14 @@ defmodule OurFitnessPalApiWeb.ExerciseControllerTest do
   @tag :authenticated
   test "#delete removes an exercise record and returns a list of exercises", %{conn: conn} do
     exercise = Factory.insert(:exercise)
-
     conn = delete conn, Routes.exercise_path(conn, :delete, exercise)
 
-    exercises = Workouts.list_exercises
-
-    assert exercises == []
-
     assert json_response(conn, 200) == %{
-      "exercises" => [],
+      "exercise" => %{
+        "name" => exercise.name,
+        "description" => exercise.description,
+        "id" => exercise.id
+      },
       "message" => "Exercise deleted"
     }
   end


### PR DESCRIPTION
Why?
- This is standard functionality when deleting something. The previous method of returning the entire list of exercises was not necessary.